### PR TITLE
Add `HTTP-Referer` and `X-Title` to requests for OpenRouter tracking.

### DIFF
--- a/ask
+++ b/ask
@@ -152,6 +152,8 @@ if [ "$STREAMING" = true ]; then
     curl -sS "$API_URL" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+      -H "HTTP-Referer: https://github.com/kagisearch/ask/" \
+      -H "X-Title: Kagi ask" \
       -d "$JSON_PAYLOAD" 2>&1 | while IFS= read -r line; do
         # Check for errors
         if echo "$line" | grep -q '"error"'; then
@@ -179,6 +181,8 @@ else
     response=$(curl -sS "$API_URL" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+      -H "HTTP-Referer: https://github.com/kagisearch/ask/" \
+      -H "X-Title: Kagi ask" \
       -d "$JSON_PAYLOAD" 2>&1)
 
     # Check for errors


### PR DESCRIPTION
Added the 'HTTP-Referer' and 'X-Title' headers to `curl` requests to allow for easy identification of `ask` requests in OpenRouter activity.

See: [App Attribution](https://openrouter.ai/docs/app-attribution)